### PR TITLE
KAN-74 feat(timetables) add deletion logic and uuid

### DIFF
--- a/backend/src/main/java/org/acme/TimetableResource.java
+++ b/backend/src/main/java/org/acme/TimetableResource.java
@@ -4,6 +4,7 @@ import ai.timefold.solver.core.api.solver.SolverManager;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -41,6 +42,8 @@ public class TimetableResource {
         jobId += 1;
         String name = "Job" + Integer.toString(jobId);
 
+        findByCampusAndDelete(problem.campusName);
+
         // generate solution timetable with TimeFold Solver
         Timetable solution = solverManager.solve(name, problem).getFinalBestSolution();
 
@@ -62,6 +65,17 @@ public class TimetableResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public Unit handleUnit(Unit unit) {
         return unit;
+    }
+
+    public void findByCampusAndDelete(String campusName) {
+        List<Timetable> timetables = Timetable.listAll();
+        for (Timetable timetable : timetables) {
+            System.out.println("CHECKING NOW\n");
+            if (campusName.equals(timetable.campusName)) {
+                System.out.println("SMTH HAS BEEN DELETED WOOOO\n");
+                timetable.delete();
+            }
+        }
     }
 
     @GET
@@ -88,7 +102,7 @@ public class TimetableResource {
         Unit u3 = new Unit(3, "3", "Course B", Duration.ofHours(2), List.of(f, g, h, i), false);
         Unit u4 = new Unit(4, "4", "Course C", Duration.ofHours(2), List.of(a, b), false);
 
-        var problem = new Timetable(
+        var problem = new Timetable("Campus A",
                 List.of(
                         u1, u2, u3, u4
 //                        new Unit(5, "5", Duration.ofHours(2), List.of(c, d, e)),
@@ -126,6 +140,9 @@ public class TimetableResource {
          * timetable assignment, while the 'new' Unit does not have the list 
          * of students enrolled, but does have the assigned date and room
          */
+
+        findByCampusAndDelete(problem.campusName);
+
         Timetable solution = solverManager.solve("job 1", problem).getFinalBestSolution();
 
         solution.persist();     

--- a/backend/src/main/java/org/acme/TimetableResource.java
+++ b/backend/src/main/java/org/acme/TimetableResource.java
@@ -4,7 +4,6 @@ import ai.timefold.solver.core.api.solver.SolverManager;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -21,6 +20,8 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import java.util.UUID;
+
 /**
  * Entry to the timetabling program.
  * Receives a timetabling problem and outputs the solution
@@ -34,13 +35,14 @@ public class TimetableResource {
     @Inject
     SolverManager<Timetable, String> solverManager;
 
-    private int jobId = 0;
-
     @POST
     @Transactional
     public Timetable handleRequest(Timetable problem) throws ExecutionException, InterruptedException {
-        jobId += 1;
-        String name = "Job" + Integer.toString(jobId);
+        UUID uuid = UUID.randomUUID();
+        String uuidAsString = uuid.toString();
+
+        System.out.println("Your UUID is: " + uuidAsString);
+        String name = "Job" + uuidAsString;
 
         findByCampusAndDelete(problem.campusName);
 

--- a/backend/src/main/java/org/acme/domain/Room.java
+++ b/backend/src/main/java/org/acme/domain/Room.java
@@ -43,7 +43,7 @@ public class Room extends PanacheEntity {
      * A list of timetables that the Room is a part of
      */
     @JsonIgnoreProperties("rooms")
-    @ManyToMany(mappedBy = "rooms", fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+    @ManyToMany(mappedBy = "rooms", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonIgnore
     public List<Timetable> timetables = new ArrayList<Timetable>();
 

--- a/backend/src/main/java/org/acme/domain/Student.java
+++ b/backend/src/main/java/org/acme/domain/Student.java
@@ -26,7 +26,7 @@ public class Student extends PanacheEntity{
     public String name;
 
     @JsonIgnoreProperties("students")
-    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(
         name = "student_unit",
         joinColumns = @JoinColumn(name = "student_id"),

--- a/backend/src/main/java/org/acme/domain/Timetable.java
+++ b/backend/src/main/java/org/acme/domain/Timetable.java
@@ -49,7 +49,7 @@ public class Timetable extends PanacheEntity {
      * campus, hence the many-to-many relationship
      */
     @JsonIgnoreProperties("timetables")
-    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(
         name = "room_timetable",
         joinColumns = @JoinColumn(name = "timetable_id"),
@@ -66,7 +66,7 @@ public class Timetable extends PanacheEntity {
      * multiple campuses, so may appear in multiple timetables
      */
     @JsonIgnoreProperties("timetables")
-    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(
         name = "unit_timetable",
         joinColumns = @JoinColumn(name = "timetable_id"),
@@ -88,7 +88,8 @@ public class Timetable extends PanacheEntity {
      * @param units      The list of units to be allocated.
      * @param startTimes The list of available starting times.
      */
-    public Timetable(List<Unit> units, List<LocalTime> startTimes) {
+    public Timetable(String campusName, List<Unit> units, List<LocalTime> startTimes) {
+        this.campusName = campusName;
         this.units = units;
         this.startTimes = startTimes;
         this.setUnitTimetable();
@@ -101,7 +102,8 @@ public class Timetable extends PanacheEntity {
      * @param startTimes The list of available starting times.
      * @param rooms      The list of available rooms.
      */
-    public Timetable(List<Unit> units, List<LocalTime> startTimes, List<Room> rooms) {
+    public Timetable(String campusName, List<Unit> units, List<LocalTime> startTimes, List<Room> rooms) {
+        this.campusName = campusName;
         this.units = units;
         this.startTimes = startTimes;
         this.rooms = rooms;
@@ -117,7 +119,8 @@ public class Timetable extends PanacheEntity {
      * @param startTimes The list of available starting times.
      * @param rooms      The list of available rooms.
      */
-    public Timetable(List<Unit> units, List<DayOfWeek> daysOfWeek, List<LocalTime> startTimes, List<Room> rooms) {
+    public Timetable(String campusName, List<Unit> units, List<DayOfWeek> daysOfWeek, List<LocalTime> startTimes, List<Room> rooms) {
+        this.campusName = campusName;
         this.units = units;
         this.daysOfWeek = daysOfWeek;
         this.startTimes = startTimes;

--- a/backend/src/main/java/org/acme/domain/Unit.java
+++ b/backend/src/main/java/org/acme/domain/Unit.java
@@ -46,7 +46,7 @@ public class Unit extends PanacheEntity {
 
     // TODO: change unit to be the owner, rather than the student being owner
     @JsonIgnoreProperties("units")
-    @ManyToMany(mappedBy = "units", fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+    @ManyToMany(mappedBy = "units", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     public List<Student> students;
 
     /*
@@ -57,7 +57,7 @@ public class Unit extends PanacheEntity {
      * etc.
      */
     @JsonIgnoreProperties("units")
-    @ManyToOne(cascade = {CascadeType.ALL})
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "room_id")
     @PlanningVariable
     public Room room;
@@ -68,7 +68,7 @@ public class Unit extends PanacheEntity {
      * The timetables that the Unit object belongs to
      */
     @JsonIgnoreProperties("units")
-    @ManyToMany(mappedBy = "units", fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+    @ManyToMany(mappedBy = "units", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonIgnore
     public List<Timetable> timetables = new ArrayList<Timetable>();
 


### PR DESCRIPTION
Testing deletion logic
- run backend (can run frontend too if you're feeling fancy but not needed)
- run hard-coded timetabling problem by going to endpoint `http://localhost:8080/timetabling`
- in the same session, run that endpoint AGAIN
- check endpoint `http://localhost:8080/timetabling/view` to see a list of all timetables stored, there should always only be 1 timetable there because hard-coded problem will have the same `campusName` each time.

Testing uuid
- run both frontend and backend
- send JSON to backend on UI
- lookout for print statement in backend terminal for uuid

