### PR TITLE
KAN 75 fix(database): fix db persistence timeout and connection lost errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 # env variables
 .env
+**/logs/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -43,3 +43,6 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+
+# logs
+**/logs/

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -92,6 +92,10 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>
+    <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-metrics</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-agroal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
@@ -93,8 +97,12 @@
         <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>
     <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-smallrye-metrics</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-narayana-jta</artifactId>
     </dependency>
   </dependencies>
 

--- a/backend/src/main/java/org/acme/TimetableResource.java
+++ b/backend/src/main/java/org/acme/TimetableResource.java
@@ -93,9 +93,9 @@ public class TimetableResource {
         Student h = new Student("h");
         Student i = new Student("i");
 
-        Room r1 = new Room("Room1", 2, true);
-        Room r2 = new Room("Room2", 4, false);
-        Room r3 = new Room("Room3", 4, false);
+        Room r1 = new Room("Room1", "building A", "campus A", 2, true);
+        Room r2 = new Room("Room2", "building B", "campus A", 4, false);
+        Room r3 = new Room("Room3", "building A", "campus B", 4, false);
 
         Unit u1 = new Unit(1, "1", "Course A", Duration.ofHours(2), List.of(a, b), true);
         Unit u2 = new Unit(2, "2", "Course A", Duration.ofHours(2), List.of(a, c, d, e), true);

--- a/backend/src/main/java/org/acme/TimetableResource.java
+++ b/backend/src/main/java/org/acme/TimetableResource.java
@@ -72,9 +72,7 @@ public class TimetableResource {
     public void findByCampusAndDelete(String campusName) {
         List<Timetable> timetables = Timetable.listAll();
         for (Timetable timetable : timetables) {
-            System.out.println("CHECKING NOW\n");
             if (campusName.equals(timetable.campusName)) {
-                System.out.println("SMTH HAS BEEN DELETED WOOOO\n");
                 timetable.delete();
             }
         }

--- a/backend/src/main/java/org/acme/domain/Room.java
+++ b/backend/src/main/java/org/acme/domain/Room.java
@@ -27,6 +27,8 @@ public class Room extends PanacheEntity {
 
     public String buildingId;
 
+    public String campus;
+
     public int capacity;
 
     public boolean isLab;
@@ -53,12 +55,16 @@ public class Room extends PanacheEntity {
     /**
      * Creates a room with its ID and capacity.
      *
-     * @param id       The room’s id.
-     * @param capacity The room's capacity.
-     * @param isLab    Whether the room is a laboratory.
+     * @param id            The room’s id.
+     * @param buildingId    The building that the room belongs to.
+     * @param buildingId    The campus that the room belongs to.
+     * @param capacity      The room's capacity.
+     * @param isLab         Whether the room is a laboratory.
      */
-    public Room(String id, int capacity, boolean isLab) {
+    public Room(String id, String buildingId, String campus, int capacity, boolean isLab) {
         this.roomCode = id;
+        this.buildingId = buildingId;
+        this.campus = campus;
         this.capacity = capacity;
         this.isLab = isLab;
     }

--- a/backend/src/main/java/org/acme/domain/Unit.java
+++ b/backend/src/main/java/org/acme/domain/Unit.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Transient;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -45,9 +46,12 @@ public class Unit extends PanacheEntity {
     public LocalTime startTime;
 
     // TODO: change unit to be the owner, rather than the student being owner
+    @Transient
     @JsonIgnoreProperties("units")
     @ManyToMany(mappedBy = "units", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     public List<Student> students;
+
+    public int studentSize;
 
     /*
      * currently each unit only has 1 'slot' on the timetable, so it can only
@@ -90,6 +94,7 @@ public class Unit extends PanacheEntity {
         this.course = course;
         this.duration = duration;
         this.students = students;
+        this.studentSize = this.students.size();
         this.setStudentsUnits();
     }
 
@@ -109,6 +114,7 @@ public class Unit extends PanacheEntity {
         this.course = course;
         this.duration = duration;
         this.students = students;
+        this.studentSize = this.students.size();
         this.wantsLab = wantsLab;
         this.setStudentsUnits();
     }
@@ -132,6 +138,7 @@ public class Unit extends PanacheEntity {
         this.startTime = startTime;
         this.duration = duration;
         this.students = students;
+        this.studentSize = this.students.size();
         this.wantsLab = wantsLab;
         this.room = room;
     }
@@ -206,7 +213,7 @@ public class Unit extends PanacheEntity {
      * @return An int representing the number of students.
      */
     public int getStudentSize() {
-        return students.size();
+        return this.studentSize;
     }
 
     public Room getRoom() {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.http.port=${PORT:8080}
 
 # The solver runs only for 5 seconds to avoid a HTTP timeout in this simple implementation.
 # It's recommended to run for at least 5 minutes ("5m") otherwise.
-quarkus.timefold.solver.termination.spent-limit=5s
+quarkus.timefold.solver.termination.spent-limit=6s
 quarkus.http.cors=true
 quarkus.http.cors.origins=*
 quarkus.http.cors.methods=GET,POST,PUT,DELETE,OPTIONS
@@ -16,3 +16,16 @@ quarkus.datasource.jdbc.url = ${QUARKUS_DATASOURCE_JDBC_URL}
 
 # drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.database.generation = create-drop
+
+# datasource metrics
+quarkus.datasource.metrics.enabled=true
+quarkus.datasource.jdbc.enable-metrics=true
+
+# datasource log leak
+quarkus.datasource.jdbc.log-leak-detection=true
+
+# transaction timeout
+quarkus.transaction-manager.default-transaction-timeout=320s
+
+# debugger for large/complex db transactions
+quarkus.log.category."com.arjuna".level=DEBUG

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,15 +17,58 @@ quarkus.datasource.jdbc.url = ${QUARKUS_DATASOURCE_JDBC_URL}
 # drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.database.generation = create-drop
 
-# datasource metrics
-quarkus.datasource.metrics.enabled=true
-quarkus.datasource.jdbc.enable-metrics=true
-
-# datasource log leak
-quarkus.datasource.jdbc.log-leak-detection=true
-
 # transaction timeout
 quarkus.transaction-manager.default-transaction-timeout=320s
 
+# set batch size to optimise db transactions
+quarkus.hibernate-orm.jdbc.batch_size=100
+
+# Agoral pooling config
+quarkus.datasource.jdbc.max-size=20
+quarkus.datasource.jdbc.min-size=5
+quarkus.datasource.jdbc.initial-size=10
+quarkus.datasource.jdbc.idle-removal-interval=5M
+quarkus.datasource.jdbc.max-lifetime=30M
+
+
+# -------------------------------------------
+# Debuggers
+# -------------------------------------------
+
 # debugger for large/complex db transactions
 quarkus.log.category."com.arjuna".level=DEBUG
+
+# TimeFold solver debuggers
+quarkus.log.category."ai.tim.sol.cor.imp.sol".level=DEBUG
+quarkus.log.category."ai.tim.sol.cor.imp.con".level=DEBUG
+
+# -------------------------------------------
+# Loggers
+# -------------------------------------------
+
+# log datasource metrics
+quarkus.datasource.metrics.enabled=true
+quarkus.datasource.jdbc.enable-metrics=true
+
+# log datasource leak
+quarkus.datasource.jdbc.log-leak-detection=true
+
+# log transactions
+quarkus.log.category."org.hibernate.engine.transaction.internal.TransactionImpl".level=DEBUG
+quarkus.log.category."org.hibernate.engine.transaction.spi.AbstractTransactionImpl".level=DEBUG
+quarkus.log.category."org.hibernate.resource.jdbc.internal.LogicalConnectionImpl".level=DEBUG
+quarkus.log.category."org.hibernate.SQL".level=DEBUG
+quarkus.log.category."org.jboss.logging".level=DEBUG
+quarkus.hibernate-orm.statistics=true
+quarkus.hibernate-orm.log-session-metrics=true
+quarkus.hibernate-orm.metrics.enabled=true
+
+# log sql commands
+# quarkus.hibernate-orm.log.sql=true
+# quarkus.hibernate-orm.format-sql=true
+
+# enable logfile
+quarkus.log.file.enable=true
+quarkus.log.file.path=logs/quarkus.log
+quarkus.log.file.rotation.max-file-size=10M
+quarkus.log.file.rotation.max-backup-index=10

--- a/backend/src/test/java/org/acme/solver/TimetableConstraintProviderTest.java
+++ b/backend/src/test/java/org/acme/solver/TimetableConstraintProviderTest.java
@@ -15,9 +15,9 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class TimetableConstraintProviderTest {
-    private static final Room ROOM1 = new Room("1", 2, true);
-    private static final Room ROOM2 = new Room("2", 2, false);
-    private static final Room ROOM3 = new Room("3", 2, true);
+    private static final Room ROOM1 = new Room("1", "building A", "campus A", 2, true);
+    private static final Room ROOM2 = new Room("2", "building B", "campus A", 2, false);
+    private static final Room ROOM3 = new Room("3", "building A", "campus B", 2, true);
     private static final Student STUDENT1 = new Student("student1");
     private static final Student STUDENT2 = new Student("student2");
     private static final Student STUDENT3 = new Student("student3");


### PR DESCRIPTION
### Testing this PR
Testing large input file:
- run frontend and backend
- upload  file of 11k students
- go through timetable generation process
- verify that an output is displayed within 10 seconds

Testing timefold solving timeout limit:
- set `quarkus.timefold.solver.termination.spent-limit=60s` in `application.properties`
- run frontend and backend
- upload any test input file
- verify that no errors are thrown and successfully generates timetable after the 60s

### Commits Overview
Commit 1: extend db transaction timeout limit to 320s
- This prevents server timeout if we choose to let the TimeFold algorithm run for longer than 60s, because timeout limit defaults to 60s

Commit 2: add logging metrics and enable logfiles
- logged info will appear in the backend terminal once Quarkus app is running
- The same info will be logged to a `.log` file inside a folder named `logs`, which lives inside the backend directory

Commit 3: remove storage of students in Unit class to speed up database Timetable object persistence 
- The storage of students is the most resource-intensive operation, which caused lost-connection errors when persisting because it was taking so long
- Our current codebase does not retrieve the Student objects after timetables are generated, therefore, they are no longer stored in the database 